### PR TITLE
Merge mac branch: skills, lazygit, and git config

### DIFF
--- a/config/claude/skills/user/commit/INSTRUCTIONS.md
+++ b/config/claude/skills/user/commit/INSTRUCTIONS.md
@@ -121,7 +121,17 @@ EOF
 
 Body only when non-obvious. Skip for trivial changes.
 
-### 7. Interactive Staging (when needed)
+### 7. Pre-commit Hook Failures (ESLint)
+
+If a commit fails due to **ESLint errors** and the project has an `eslint.config.js`:
+
+1. Invoke the `eslint-fix` skill to fix errors on the staged files
+2. Re-stage the fixed files
+3. Retry the commit (new commit, NOT `--amend`)
+
+Only for ESLint failures — handle other pre-commit issues (Prettier, types) directly.
+
+### 8. Interactive Staging (when needed)
 
 For files with mixed concerns, use `git add -p` to split hunks:
 

--- a/config/claude/skills/user/eslint-fix/INSTRUCTIONS.md
+++ b/config/claude/skills/user/eslint-fix/INSTRUCTIONS.md
@@ -1,0 +1,32 @@
+# eslint-fix
+
+Fix ESLint errors that `eslint --fix` can't auto-resolve.
+
+## Workflow
+
+1. **Get staged files** — only lint what's being committed:
+
+```sh
+git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx'
+```
+
+If no staged TS/TSX files, nothing to do.
+
+2. **Run ESLint** on those files only:
+
+```sh
+yarn eslint <files> 2>&1
+```
+
+Do NOT run `yarn lint` or lint the whole repo — only the staged files.
+
+3. **Fix each error** by reading the file and editing the code. Read surrounding code to understand intent before fixing.
+
+4. **Re-run ESLint** on the fixed files to verify — repeat until clean.
+
+## Notes
+
+- Only fix errors in staged files — don't touch unstaged files.
+- Do NOT use `@ts-ignore`, `eslint-disable`, or other suppressions unless the user explicitly asks.
+- Prefer minimal, targeted fixes — don't refactor surrounding code.
+- If a fix is ambiguous, ask the user.

--- a/config/claude/skills/user/eslint-fix/INSTRUCTIONS.md
+++ b/config/claude/skills/user/eslint-fix/INSTRUCTIONS.md
@@ -1,10 +1,12 @@
 # eslint-fix
 
-Fix ESLint errors that `eslint --fix` can't auto-resolve.
+Fix ESLint and TypeScript errors in **leadpierui/** only. All commands must run from the `leadpierui/` project root. Ignore any non-TS/TSX errors (e.g., Go files, other repos).
 
-## Workflow
+## Subcommands
 
-1. **Get staged files** — only lint what's being committed:
+### Default (no args) — Fix staged ESLint errors
+
+1. **Get staged files:**
 
 ```sh
 git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx'
@@ -24,9 +26,44 @@ Do NOT run `yarn lint` or lint the whole repo — only the staged files.
 
 4. **Re-run ESLint** on the fixed files to verify — repeat until clean.
 
+### `push` — Push with automatic error fixing
+
+1. **Attempt push:**
+
+```sh
+git push 2>&1
+```
+
+Never force push. If push succeeds, done.
+
+2. **On failure**, parse the error output. The pre-push hook runs `tsc -b --noEmit` (type check) and on `dev` branch also `yarn test`. Only process TypeScript errors (`.ts`/`.tsx` files) — **ignore** Go errors, go.mod warnings, or any output from other repos. TS errors follow this format:
+
+```
+path/to/file.tsx:LINE:COL - error TSXXXX: message
+```
+
+3. **Fix each error** by reading the file and editing the code. Group fixes by file. Common patterns:
+   - `TS2307` (module not found) — fix import path
+   - `TS2322` (type mismatch) — fix prop types or type annotations
+   - `TS2339` (property doesn't exist) — add to type/interface or fix access
+   - `TS2367` (unintentional comparison) — add value to enum/union type
+   - `TS7006` (implicit any) — add type annotation
+   - `TS7031` (binding element implicit any) — add type to destructured param
+
+4. **Run type check** to verify fixes:
+
+```sh
+yarn lint:types 2>&1
+```
+
+Repeat fix cycle until clean.
+
+5. **Commit fixes and retry push** — stage changed files, commit with a message like "fix: resolve type errors", then `git push` again.
+
 ## Notes
 
-- Only fix errors in staged files — don't touch unstaged files.
+- Only fix errors in relevant files — don't touch unrelated code.
 - Do NOT use `@ts-ignore`, `eslint-disable`, or other suppressions unless the user explicitly asks.
 - Prefer minimal, targeted fixes — don't refactor surrounding code.
 - If a fix is ambiguous, ask the user.
+- Never use `--no-verify` to skip hooks.

--- a/config/claude/skills/user/eslint-fix/SKILL.md
+++ b/config/claude/skills/user/eslint-fix/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: eslint-fix
+description: Fix ESLint errors in the leadpierui codebase. Use when user says /eslint-fix, asks to fix lint errors, or when a pre-commit hook fails due to ESLint. Runs lint, parses errors, and applies code fixes.
+invocation: user
+---
+
+Run `/eslint-fix` to find and fix ESLint errors.

--- a/config/claude/skills/user/eslint-fix/SKILL.md
+++ b/config/claude/skills/user/eslint-fix/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: eslint-fix
-description: Fix ESLint errors in the leadpierui codebase. Use when user says /eslint-fix, asks to fix lint errors, or when a pre-commit hook fails due to ESLint. Runs lint, parses errors, and applies code fixes.
+description: Fix ESLint/TS errors in leadpierui (TS/TSX only, ignore Go/other repos). Use when user says /eslint-fix, asks to fix lint errors, or when a pre-commit/pre-push hook fails. Use `/eslint-fix push` to push with automatic type error fixing.
 invocation: user
 ---
 
-Run `/eslint-fix` to find and fix ESLint errors.
+- `/eslint-fix` — fix ESLint errors in staged files
+- `/eslint-fix push` — push, fix type/lint errors from pre-push hook, commit, retry

--- a/config/git/config
+++ b/config/git/config
@@ -17,3 +17,5 @@
 	insteadOf = https://git.linecode.net/
 [url "git@git.linecode.dev:"]
 	insteadOf = https://git.linecode.dev/
+[include]
+	path = ~/.config/git/config-mac

--- a/config/git/config-mac
+++ b/config/git/config-mac
@@ -1,0 +1,3 @@
+[user]
+	email = cullyn@trendcapital.com
+	signingkey = /Users/cullyn/.ssh/id_ed25519.pub

--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,0 +1,8 @@
+gui:
+  showCommandLog: false
+promptToReturnFromSubprocess: false
+git:
+  overrideGpg: true
+os:
+  edit: "nvim {{filename}}"
+  editAtLine: "nvim +{{line}} {{filename}}"

--- a/config/shell/env.sh
+++ b/config/shell/env.sh
@@ -6,6 +6,7 @@ export GOPATH="$HOME/.go"
 # export TERM=xterm-256color  # Let terminal set its own (kitty needs xterm-kitty for undercurls)
 export PAGER=nvimpager
 export EDITOR=nvim
+export VISUAL=nvim
 export DOTS="$HOME/dotfiles"
 export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
 


### PR DESCRIPTION
## Summary
- Add eslint-fix skill for staged file linting with push subcommand
- Extend commit skill with eslint pre-commit hook handling
- Extend learn skill audit with symlink validation
- Add lazygit config
- Update git config (includes config-mac)

## Commits
Cherry-picked from `mac` branch:
- `2bd5aa72` add(claude/skills): eslint-fix skill for staged file linting
- `6cdf4c6f` extend(claude/skills/commit): add eslint pre-commit hook handling
- `fc3dcccb` extend(claude/skills/eslint-fix): add push subcommand and scope to TS/TSX
- `1659e7c2` extend(claude/skills/learn): add symlink validation to audit script
- `67168ec3` lazygit view
- `d35358f5` git config